### PR TITLE
feat(core): scaffold v0 structure

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    branches: [main, next]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm turbo lint
+      - run: pnpm turbo typecheck
+      - run: pnpm turbo test
+      - run: pnpm turbo build

--- a/my-rules.mix.md
+++ b/my-rules.mix.md
@@ -1,0 +1,6 @@
+---
+mixdown: v0
+title: My First Mixdown Rule
+---
+# Body
+This is a paragraph.

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "Rules compiler for AI tools",
   "private": true,
   "scripts": {
-    "build": "pnpm --filter=\"@mixdown/*\" build",
-    "dev": "pnpm --filter=\"@mixdown/core\" dev",
-    "test": "pnpm --filter=\"@mixdown/*\" test",
-    "lint": "pnpm --filter=\"@mixdown/*\" lint",
+    "build": "turbo build",
+    "dev": "turbo dev",
+    "test": "turbo test",
+    "lint": "turbo lint",
+    "typecheck": "turbo typecheck",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "changeset publish"
+    "release": "turbo build --filter=@mixdown/core && changeset publish"
   },
   "author": "Maybe Good Systems",
   "license": "MIT",
@@ -23,6 +24,9 @@
     "@changesets/cli": "^2.26.2",
     "eslint": "8.37.0",
     "prettier": "^3.0.3",
-    "@types/node": "20.5.1"
+    "@types/node": "20.5.1",
+    "turbo": "^2.0.6",
+    "typescript": "^5.4.5",
+    "markdownlint-cli": "^0.41.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,25 +1,33 @@
 {
   "name": "@mixdown/core",
-  "version": "0.1.0",
-  "description": "Core compiler for Mixdown - a CommonMark-compliant prompt compiler",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Core library for Mixdown: parser, compiler, linter, and plugins.",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "jest",
-    "lint": "eslint src/**/*.ts"
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
-    "marked": "^9.0.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.0",
-    "@types/js-yaml": "^4.0.5",
-    "@types/marked": "^5.0.0",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.1.0",
-    "typescript": "^5.0.4"
-  }
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^18.19.31",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "eslint": "^8.57.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
 }

--- a/packages/core/src/compiler/__tests__/compiler.spec.ts
+++ b/packages/core/src/compiler/__tests__/compiler.spec.ts
@@ -1,0 +1,17 @@
+// TLDR: Tests for compiler pass-through behavior (mixd-v0)
+import { compile } from '../index';
+import { describe, it, expect } from 'vitest';
+import type { ParsedDoc } from '../../interfaces/compiled-doc';
+
+const parsed: ParsedDoc = {
+  source: { content: '---\nmixdown: v0\n---\nbody', frontmatter: { mixdown: 'v0' } },
+  ast: { stems: [], imports: [], variables: [], markers: [] }
+};
+
+describe('compile', () => {
+  it('passes through body content', async () => {
+    const result = await compile(parsed, 'cursor');
+    expect(result.output.content).toBe('body');
+    expect(result.context.destinationId).toBe('cursor');
+  });
+});

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -1,0 +1,20 @@
+// TLDR: Pass-through compiler for Mixdown v0 (mixd-v0)
+import type { ParsedDoc, CompiledDoc } from '../interfaces/compiled-doc';
+
+// <!-- TLDR: Compiles parsed doc for a destination without processing body -->
+export async function compile(parsed: ParsedDoc, destinationId: string, projectConfig: any = {}): Promise<CompiledDoc> {
+  const match = parsed.source.content.match(/^---\n([\s\S]*?)\n---\n?/);
+  const body = match ? parsed.source.content.slice(match[0].length) : parsed.source.content;
+  return {
+    source: parsed.source,
+    ast: parsed.ast,
+    output: {
+      content: body,
+      metadata: { ...parsed.source.frontmatter }
+    },
+    context: {
+      destinationId,
+      config: projectConfig
+    }
+  };
+}

--- a/packages/core/src/destinations/__tests__/cursor-plugin.spec.ts
+++ b/packages/core/src/destinations/__tests__/cursor-plugin.spec.ts
@@ -1,0 +1,9 @@
+// TLDR: Tests for cursor destination plugin (mixd-v0)
+import { cursorPlugin } from '../cursor-plugin';
+import { describe, it, expect } from 'vitest';
+
+describe('cursorPlugin', () => {
+  it('exposes name', () => {
+    expect(cursorPlugin.name).toBe('cursor');
+  });
+});

--- a/packages/core/src/destinations/__tests__/windsurf-plugin.spec.ts
+++ b/packages/core/src/destinations/__tests__/windsurf-plugin.spec.ts
@@ -1,0 +1,9 @@
+// TLDR: Tests for windsurf destination plugin (mixd-v0)
+import { windsurfPlugin } from '../windsurf-plugin';
+import { describe, it, expect } from 'vitest';
+
+describe('windsurfPlugin', () => {
+  it('exposes name', () => {
+    expect(windsurfPlugin.name).toBe('windsurf');
+  });
+});

--- a/packages/core/src/destinations/cursor-plugin.ts
+++ b/packages/core/src/destinations/cursor-plugin.ts
@@ -1,0 +1,13 @@
+// TLDR: Stub destination plugin for Cursor (mixd-v0)
+import { JSONSchema7 } from '../interfaces/destination-plugin';
+import type { DestinationPlugin } from '../interfaces/destination-plugin';
+import type { CompiledDoc } from '../interfaces/compiled-doc';
+import type { Logger } from '../interfaces/logger';
+
+export const cursorPlugin: DestinationPlugin = {
+  get name() { return 'cursor'; },
+  configSchema(): JSONSchema7 { return {}; },
+  async write(ctx: { compiled: CompiledDoc; destPath: string; config: Record<string, any>; logger: Logger; }): Promise<void> {
+    ctx.logger.info(`Writing Cursor output to ${ctx.destPath}`);
+  }
+};

--- a/packages/core/src/destinations/index.ts
+++ b/packages/core/src/destinations/index.ts
@@ -1,0 +1,3 @@
+// TLDR: Exports destination plugins (mixd-v0)
+export { cursorPlugin } from './cursor-plugin';
+export { windsurfPlugin } from './windsurf-plugin';

--- a/packages/core/src/destinations/windsurf-plugin.ts
+++ b/packages/core/src/destinations/windsurf-plugin.ts
@@ -1,0 +1,13 @@
+// TLDR: Stub destination plugin for Windsurf (mixd-v0)
+import { JSONSchema7 } from '../interfaces/destination-plugin';
+import type { DestinationPlugin } from '../interfaces/destination-plugin';
+import type { CompiledDoc } from '../interfaces/compiled-doc';
+import type { Logger } from '../interfaces/logger';
+
+export const windsurfPlugin: DestinationPlugin = {
+  get name() { return 'windsurf'; },
+  configSchema(): JSONSchema7 { return {}; },
+  async write(ctx: { compiled: CompiledDoc; destPath: string; config: Record<string, any>; logger: Logger; }): Promise<void> {
+    ctx.logger.info(`Writing Windsurf output to ${ctx.destPath}`);
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,17 @@
+// TLDR: Mixdown v0 orchestration entry point (mixd-v0)
+import { parse } from './parser';
+import { lint } from './linter';
+import { compile } from './compiler';
+import { cursorPlugin, windsurfPlugin } from './destinations';
+import type { Logger } from './interfaces/logger';
+
+// <!-- TLDR: Runs the Mixdown v0 process for a single file -->
+export async function runMixdownV0(source: string, logger: Logger): Promise<void> {
+  const parsed = await parse(source);
+  const lintResults = await lint(parsed);
+  lintResults.forEach(r => logger.info(r.message));
+  const compiledCursor = await compile(parsed, 'cursor');
+  await cursorPlugin.write({ compiled: compiledCursor, destPath: '.mixdown/dist/cursor/output.md', config: {}, logger });
+  const compiledWindsurf = await compile(parsed, 'windsurf');
+  await windsurfPlugin.write({ compiled: compiledWindsurf, destPath: '.mixdown/dist/windsurf/output.md', config: {}, logger });
+}

--- a/packages/core/src/interfaces/compiled-doc.ts
+++ b/packages/core/src/interfaces/compiled-doc.ts
@@ -1,0 +1,54 @@
+// TLDR: Defines the CompiledDoc interface for Mixdown output (mixd-v0)
+
+export interface Stem {
+  name: string;
+}
+
+export interface Import {
+  path: string;
+}
+
+export interface Variable {
+  name: string;
+}
+
+export interface Marker {
+  type: 'stem' | 'import' | 'variable' | 'unknown';
+}
+
+export interface ParsedDoc {
+  source: {
+    path?: string;
+    content: string;
+    frontmatter?: Record<string, any>;
+  };
+  ast: {
+    stems: Stem[];
+    imports: Import[];
+    variables: Variable[];
+    markers: Marker[];
+  };
+  errors?: Array<{ message: string; line?: number; column?: number }>;
+}
+
+export interface CompiledDoc {
+  source: {
+    path?: string;
+    content: string;
+    frontmatter?: Record<string, any>;
+  };
+  ast: {
+    stems: Stem[];
+    imports: Import[];
+    variables: Variable[];
+    markers: Marker[];
+  };
+  output: {
+    content: string;
+    metadata?: Record<string, any>;
+  };
+  context: {
+    destinationId: string;
+    config: Record<string, any>;
+  };
+}

--- a/packages/core/src/interfaces/destination-plugin.ts
+++ b/packages/core/src/interfaces/destination-plugin.ts
@@ -1,0 +1,12 @@
+// TLDR: Defines the DestinationPlugin interface for output plugins (mixd-v0)
+import type { JSONSchema7 } from 'json-schema';
+import type { CompiledDoc } from './compiled-doc';
+import type { Logger } from './logger';
+
+export { JSONSchema7 };
+
+export interface DestinationPlugin {
+  get name(): string;
+  configSchema(): JSONSchema7;
+  write(ctx: { compiled: CompiledDoc; destPath: string; config: Record<string, any>; logger: Logger; }): Promise<void>;
+}

--- a/packages/core/src/interfaces/logger.ts
+++ b/packages/core/src/interfaces/logger.ts
@@ -1,0 +1,35 @@
+// TLDR: Defines the Logger interface for Mixdown. Provides logging contract (mixd-v0)
+export interface Logger {
+  // <!-- TLDR: Logs a debug message (mixd-v0) -->
+  debug(message: string, ...args: any[]): void;
+  // <!-- TLDR: Logs an informational message (mixd-v0) -->
+  info(message: string, ...args: any[]): void;
+  // <!-- TLDR: Logs a warning message (mixd-v0) -->
+  warn(message: string, ...args: any[]): void;
+  // <!-- TLDR: Logs an error message (mixd-v0) -->
+  error(message: string | Error, ...args: any[]): void;
+}
+
+// Basic console logger implementation for v0
+export class ConsoleLogger implements Logger {
+  // <!-- TLDR: Logs a debug message to the console (mixd-v0) -->
+  public debug(message: string, ...args: any[]): void {
+    console.debug(`[DEBUG] ${message}`, ...args);
+  }
+  // <!-- TLDR: Logs an informational message to the console (mixd-v0) -->
+  public info(message: string, ...args: any[]): void {
+    console.info(`[INFO] ${message}`, ...args);
+  }
+  // <!-- TLDR: Logs a warning message to the console (mixd-v0) -->
+  public warn(message: string, ...args: any[]): void {
+    console.warn(`[WARN] ${message}`, ...args);
+  }
+  // <!-- TLDR: Logs an error message to the console (mixd-v0) -->
+  public error(message: string | Error, ...args: any[]): void {
+    if (message instanceof Error) {
+      console.error(`[ERROR] ${message.message}`, message.stack, ...args);
+    } else {
+      console.error(`[ERROR] ${message}`, ...args);
+    }
+  }
+}

--- a/packages/core/src/linter/__tests__/linter.spec.ts
+++ b/packages/core/src/linter/__tests__/linter.spec.ts
@@ -1,0 +1,21 @@
+// TLDR: Tests for linter frontmatter validation (mixd-v0)
+import { lint } from '../index';
+import { describe, it, expect } from 'vitest';
+import type { ParsedDoc } from '../../interfaces/compiled-doc';
+
+const parsed: ParsedDoc = {
+  source: { content: '---\nmixdown: v0\n---\nbody', frontmatter: { mixdown: 'v0' } },
+  ast: { stems: [], imports: [], variables: [], markers: [] }
+};
+
+describe('lint', () => {
+  it('returns error when mixdown key missing', async () => {
+    const bad: ParsedDoc = { ...parsed, source: { content: '---\n---\n', frontmatter: {} } };
+    const res = await lint(bad);
+    expect(res.length).toBe(1);
+  });
+  it('passes when mixdown key present', async () => {
+    const res = await lint(parsed);
+    expect(res.length).toBe(0);
+  });
+});

--- a/packages/core/src/linter/index.ts
+++ b/packages/core/src/linter/index.ts
@@ -1,0 +1,22 @@
+// TLDR: Validate frontmatter schema (mixd-v0)
+import type { ParsedDoc } from '../interfaces/compiled-doc';
+
+export interface LintResult {
+  message: string;
+  line?: number;
+  column?: number;
+  severity: 'error' | 'warning';
+}
+
+export interface LinterConfig {
+  requiredMixdownKey?: boolean;
+}
+
+// <!-- TLDR: Lints parsed document frontmatter -->
+export async function lint(parsed: ParsedDoc, config: LinterConfig = { requiredMixdownKey: true }): Promise<LintResult[]> {
+  const results: LintResult[] = [];
+  if (config.requiredMixdownKey && (!parsed.source.frontmatter || !parsed.source.frontmatter.mixdown)) {
+    results.push({ message: 'Missing required "mixdown" frontmatter key', severity: 'error' });
+  }
+  return results;
+}

--- a/packages/core/src/parser/__tests__/parser.spec.ts
+++ b/packages/core/src/parser/__tests__/parser.spec.ts
@@ -1,0 +1,12 @@
+// TLDR: Tests for parser frontmatter extraction (mixd-v0)
+import { parse } from '../index';
+import { describe, it, expect } from 'vitest';
+
+describe('parse', () => {
+  it('extracts frontmatter and body', async () => {
+    const content = `---\nmixdown: v0\ntitle: Test\n---\nbody text`;
+    const result = await parse(content);
+    expect(result.source.frontmatter?.mixdown).toBe('v0');
+    expect(result.source.content).toBe(content);
+  });
+});

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -1,0 +1,17 @@
+// TLDR: Parse frontmatter and body from Markdown content (mixd-v0)
+import { load } from 'js-yaml';
+import type { ParsedDoc } from '../interfaces/compiled-doc';
+
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?/;
+
+// <!-- TLDR: Parses Markdown content into frontmatter and body -->
+export async function parse(content: string): Promise<ParsedDoc> {
+  const match = content.match(FRONTMATTER_REGEX);
+  const frontmatter = match ? (load(match[1]) as Record<string, any>) : undefined;
+  const body = match ? content.slice(match[0].length) : content;
+  return {
+    source: { content, frontmatter },
+    ast: { stems: [], imports: [], variables: [], markers: [] },
+    errors: []
+  };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declarationMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/**/__tests__"]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  shims: true
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/interfaces/**', 'src/**/__tests__/**', 'src/**/*.spec.ts']
+    }
+  }
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "lib": ["ES2021"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "exclude": ["node_modules", "**/dist", "**/coverage"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "lint": {"outputs": []},
+    "typecheck": {"outputs": []},
+    "build": {"dependsOn": ["^build"], "outputs": ["dist/**", "tsconfig.tsbuildinfo"]},
+    "test": {"dependsOn": ["^build"], "outputs": ["coverage/**"]}
+  }
+}


### PR DESCRIPTION
## Summary
- configure monorepo tooling with Turbo, pnpm and Changesets
- add base TypeScript settings
- scaffold `@mixdown/core` package with parser, linter, compiler and stub plugins
- provide initial tests for each module
- add CI workflow for lint/typecheck/build/test

## Testing
- `pnpm turbo lint` *(fails: connect timeout)*
